### PR TITLE
Lesson1.5 technical review

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Application Structure
 
-In this short lesson we'll just be creating a few folders and files that will
+In this short lesson we'll be creating a few folders and files that will
 be necessary for us to get going on our application development.
 
 ## Example App Files
@@ -27,7 +27,7 @@ paste in this code:
 We're doing a few things here. First we're just pulling in BootStrap to give
 us some easy to use styling. Next you'll notice we have a `div` with an id
 of `react` on it. This is the container that we are going to use to mount
-our React app on.
+our React app in.
 
 The next thing I want to point out is the script tag at the bottom of the
 file. This is where our transpiled React code gets loaded. It's being loaded


### PR DESCRIPTION
Nothing really to do on this one.

I would recommend removing the babel `stage0` preset. `stage0` is made of language features that have been proposed, but have not been included in the ES2015 specification. As this is "React JS the ES6 Way", the code should not go beyond ES6, at least with out clearly explaining what a stage 0 proposal is etc etc. Not worth the extra cognitive load on the reader.
